### PR TITLE
Bind to locals

### DIFF
--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -28,7 +28,7 @@ module EJS
       escape_whitespace!(source)
 
       "function(obj){var __p=[];" +
-        "with(obj||{}){__p.push('#{source}');}return __p.join('');}"
+        "(function(){with(this){__p.push('#{source}');}}.call(obj||{}));return __p.join('');}"
     end
 
     # Evaluates an EJS template with the given local variables and

--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -27,7 +27,7 @@ module EJS
       replace_evaluation_tags!(source, options)
       escape_whitespace!(source)
 
-      "function(obj){var __p=[],print=function(){__p.push.apply(__p,arguments);};" +
+      "function(obj){var __p=[];" +
         "with(obj||{}){__p.push('#{source}');}return __p.join('');}"
     end
 

--- a/test/test_ejs.rb
+++ b/test/test_ejs.rb
@@ -143,4 +143,8 @@ class EJSEvaluationTest < Test::Unit::TestCase
     template = "<? if(foo == 'bar'){ ?>Statement quotes and 'quotes'.<? } ?>"
     assert_equal "Statement quotes and 'quotes'.", EJS.evaluate(template, { :foo => "bar" }, QUESTION_MARK_SYNTAX)
   end
+
+  test "'this' should be provided object" do
+    assert_equal "Property Value", EJS.evaluate("<%= this.property %>", { :property => "Property Value" })
+  end
 end


### PR DESCRIPTION
I'm not sure how 'print' gets used inside the EJS evaluation block, and no tests covered its usage.

I made the evaluation context bind to the provided locals object. This makes it simple to forward the provided object along to other renders. For example, in Rails, I can now create a template like this:

```
<div id="some_div">
  <%= JST['another_template'](this) %>
</div>
```
