### PR TITLE
Escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ function:
     EJS.compile("Hello <%= name %>")
     # => "function(obj){...}"
 
+Using the default syntax `<%= content %>`, content is escaped, à la Rails 3. For unescaped content, use the unescaped syntax `<%: content %>`.
+
+    EJS.compile("Hello <%: name %>")
+    # => "function(obj){...}"
+    
+About the js escape function : 
+
+By default, js is escaped using a function injected in **each** template. To avoid that, save some kb and be more DRY, you can specify your own escape function :
+
+    # Example : to use underscore.js escape function, put this in an initializer file (ex. config/initializers/ejs.rb)
+    EJS.escape_function_name = '_.escape'
+
+
 Invoke the function in a JavaScript environment to produce a string
 value. You can pass an optional object specifying local variables for
 template evaluation.

--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -10,6 +10,8 @@ module EJS
     attr_accessor :interpolation_pattern
     attr_accessor :interpolation_safe_pattern
 
+    ESCAPE_FUNCTION = "__e=function(s){return ((s==null?'':s)+'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}".freeze
+
     # Compiles an EJS template to a JavaScript function. The compiled
     # function takes an optional argument, an object specifying local
     # variables in the template.  You can optionally pass the
@@ -28,7 +30,7 @@ module EJS
       replace_interpolation_tags!(source, options)
       replace_evaluation_tags!(source, options)
       escape_whitespace!(source)
-      "function(obj){var _e=function(s){return ((s==null?'':s)+'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}, " + 
+      "function(obj){var #{ESCAPE_FUNCTION}," +
         "__p=[],print=function(){__p.push.apply(__p,arguments);};" +
         "with(obj||{}){__p.push('#{source}');}return __p.join('');}"
     end
@@ -61,7 +63,7 @@ module EJS
 
       def replace_interpolation_safe_tags!(source, options)
         source.gsub!(options[:interpolation_safe_pattern] || interpolation_safe_pattern) do
-          "',_e(" + $1.gsub(/\\'/, "'") + "),'"
+          "',__e(" + $1.gsub(/\\'/, "'") + "),'"
         end
       end
       

--- a/test/test_ejs.rb
+++ b/test/test_ejs.rb
@@ -21,6 +21,23 @@ module TestHelper
   end
 end
 
+class EJSTest < Test::Unit::TestCase
+  extend TestHelper
+
+  test "escape function if required when default" do
+    assert EJS.send(:escape_function_if_required)
+  end
+
+  test "escape function if required when _.escape" do
+    begin
+      EJS.escape_function_name = '_.escape'
+      assert_nil EJS.send(:escape_function_if_required)
+    ensure
+      EJS.escape_function_name = EJS::DEFAULT_ESCAPE_FUNCTION_NAME
+    end
+  end
+end
+
 class EJSCompilationTest < Test::Unit::TestCase
   extend TestHelper
 

--- a/test/test_ejs.rb
+++ b/test/test_ejs.rb
@@ -93,6 +93,16 @@ class EJSEvaluationTest < Test::Unit::TestCase
     assert_equal "This is \\ridanculous", EJS.evaluate(template, :thing => "This")
   end
 
+  test "not escaping" do
+    template = "Hello <%: content %>"
+    assert_equal "Hello <XSS>", EJS.evaluate(template, :content => "<XSS>")
+  end
+
+  test "escaping" do
+    template = "Hello <%= content %>"
+    assert_equal "Hello &lt;XSS&gt; &amp; co", EJS.evaluate(template, :content => "<XSS> & co")
+  end
+
   test "iteration" do
     template = "<ul><%
       for (var i = 0; i < people.length; i++) {

--- a/test/test_ejs.rb
+++ b/test/test_ejs.rb
@@ -103,6 +103,11 @@ class EJSEvaluationTest < Test::Unit::TestCase
     assert_equal "Hello &lt;XSS&gt; &amp; co", EJS.evaluate(template, :content => "<XSS> & co")
   end
 
+  test "escaping null and 0" do
+    template = "Hello <%= null %> <%= 0 %>"
+    assert_equal "Hello  0", EJS.evaluate(template)
+  end
+
   test "iteration" do
     template = "<ul><%
       for (var i = 0; i < people.length; i++) {

--- a/test/test_ejs.rb
+++ b/test/test_ejs.rb
@@ -5,12 +5,14 @@ FUNCTION_PATTERN = /^function\s*\(.*?\)\s*\{(.*?)\}$/
 
 BRACE_SYNTAX = {
   :evaluation_pattern    => /\{\{([\s\S]+?)\}\}/,
-  :interpolation_pattern => /\{\{=([\s\S]+?)\}\}/
+  :interpolation_pattern => /\{\{:([\s\S]+?)\}\}/,
+  :interpolation_safe_pattern => /\{\{=([\s\S]+?)\}\}/
 }
 
 QUESTION_MARK_SYNTAX = {
   :evaluation_pattern    => /<\?([\s\S]+?)\?>/,
-  :interpolation_pattern => /<\?=([\s\S]+?)\?>/
+  :interpolation_pattern => /<\?:([\s\S]+?)\?>/,
+  :interpolation_safe_pattern => /<\?=([\s\S]+?)\?>/
 }
 
 module TestHelper
@@ -29,6 +31,14 @@ class EJSCompilationTest < Test::Unit::TestCase
   end
 
   test "compile with custom syntax" do
+    standard_result = EJS.compile("Hello <%: name %>")
+    braced_result   = EJS.compile("Hello {{: name }}", BRACE_SYNTAX)
+
+    assert_match FUNCTION_PATTERN, braced_result
+    assert_equal standard_result, braced_result
+  end
+
+  test "compile safe tags with custom syntax " do
     standard_result = EJS.compile("Hello <%= name %>")
     braced_result   = EJS.compile("Hello {{= name }}", BRACE_SYNTAX)
 
@@ -41,14 +51,17 @@ class EJSCustomPatternTest < Test::Unit::TestCase
   extend TestHelper
 
   def setup
+    @original_safe_interpolation_pattern = EJS.interpolation_safe_pattern
     @original_evaluation_pattern = EJS.evaluation_pattern
     @original_interpolation_pattern = EJS.interpolation_pattern
     EJS.evaluation_pattern = BRACE_SYNTAX[:evaluation_pattern]
     EJS.interpolation_pattern = BRACE_SYNTAX[:interpolation_pattern]
+    EJS.interpolation_safe_pattern = BRACE_SYNTAX[:interpolation_safe_pattern]
   end
 
   def teardown
     EJS.interpolation_pattern = @original_interpolation_pattern
+    EJS.interpolation_safe_pattern = @original_safe_interpolation_pattern
     EJS.evaluation_pattern = @original_evaluation_pattern
   end
 


### PR DESCRIPTION
Sir Sam,

We've forked your ruby-ejs to implement html-escaping, in the Rails 3 fashion. 3 things mainly : 
- Escape content using <%= %>
- Unescaped content using <%: %>
- Option to specify an "external" escape js function name (ex. EJS.escape_function_name = '_.escape')

We've been using this for a month and it's working great for us.

Best Regards,
Chab & Alexis
