### PR TITLE
Automatically add semi-colon at the end of evaluation tags

### DIFF
--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -53,7 +53,7 @@ module EJS
 
       def replace_evaluation_tags!(source, options)
         source.gsub!(options[:evaluation_pattern] || evaluation_pattern) do
-          "');" + $1.gsub(/\\'/, "'").gsub(/[\r\n\t]/, ' ') + "__p.push('"
+          "');" + $1.gsub(/\\'/, "'").gsub(/[\r\n\t]/, ' ') + "; __p.push('"
         end
       end
 

--- a/test/test_ejs.rb
+++ b/test/test_ejs.rb
@@ -80,6 +80,11 @@ class EJSEvaluationTest < Test::Unit::TestCase
     assert_equal "This is \\ridanculous", EJS.evaluate(template, :thing => "This")
   end
 
+  test "implicit semicolon" do
+    template = "<% var foo = 'bar' %>"
+    assert_equal '', EJS.evaluate(template)
+  end
+
   test "iteration" do
     template = "<ul><%
       for (var i = 0; i < people.length; i++) {


### PR DESCRIPTION
To be more consistent with underscore.js template function

Example:

``` ejs
<% var foo = "bar" %>
```

Will work fine with `_.template`, but produce a syntax error with `ruby-ejs``
