### PR TITLE
Add failing case for quote escaping

### DIFF
--- a/test/test_ejs.rb
+++ b/test/test_ejs.rb
@@ -82,6 +82,11 @@ class EJSEvaluationTest < Test::Unit::TestCase
     assert_equal "This is \\ridanculous", EJS.evaluate(template, :thing => "This")
   end
 
+  test "backslashes into interpolation" do
+    template = %q{<%= "Hello \"World\"" %>}
+    assert_equal 'Hello "World"', EJS.evaluate(template)
+  end
+
   test "implicit semicolon" do
     template = "<% var foo = 'bar' %>"
     assert_equal '', EJS.evaluate(template)


### PR DESCRIPTION
Hi again.

There is another inconsistency with `_.template()`.

An expression like:

``` ejs
<%= "Hello \"World\"" %>
```

Will compile just fine with underscore but will result in a SyntaxError with EJS.

I just had the time to wrote the failing test case tonight but I will try to find a fix tomorrow.

Regards
