### PR TITLE
Use block's arg for match instead of magic $1

### DIFF
--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -68,20 +68,20 @@ module EJS
       end
 
       def replace_escape_tags!(source, options)
-        source.gsub!(options[:escape_pattern] || escape_pattern) do
-          "',(''+#{js_unescape!($1)})#{escape_function},'"
+        source.gsub!(options[:escape_pattern] || escape_pattern) do |match|
+          "',(''+#{js_unescape!(match)})#{escape_function},'"
         end
       end
 
       def replace_evaluation_tags!(source, options)
-        source.gsub!(options[:evaluation_pattern] || evaluation_pattern) do
-          "'); #{js_unescape!($1)}; __p.push('"
+        source.gsub!(options[:evaluation_pattern] || evaluation_pattern) do |match|
+          "'); #{js_unescape!(match)}; __p.push('"
         end
       end
 
       def replace_interpolation_tags!(source, options)
-        source.gsub!(options[:interpolation_pattern] || interpolation_pattern) do
-          "', #{js_unescape!($1)},'"
+        source.gsub!(options[:interpolation_pattern] || interpolation_pattern) do |match|
+          "', #{js_unescape!(match)},'"
         end
       end
 


### PR DESCRIPTION
For some reason on my Mountain Lion stock Ruby 1.8.7p358 and Rails 3.1 setup the magic $1, $& etc. semi-global variables were consistently nil in the replace_*_tags blocks, yet the block variable was properly set.

I've replaced $1 usage with the block variable to make it work and hopefully be more robust.
