### PR TITLE
Allow to use a custom function to compile the escape pattern (<%- %>)

### DIFF
--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -20,6 +20,7 @@ module EJS
     attr_accessor :evaluation_pattern
     attr_accessor :interpolation_pattern
     attr_accessor :escape_pattern
+    attr_accessor :escape_function
 
     # Compiles an EJS template to a JavaScript function. The compiled
     # function takes an optional argument, an object specifying local
@@ -69,7 +70,8 @@ module EJS
 
       def replace_escape_tags!(source, options)
         source.gsub!(options[:escape_pattern] || escape_pattern) do
-          "',(''+#{js_unescape!($1)})#{escape_function},'"
+          expression = "(''+#{js_unescape!($1)})"
+          "',#{runtime_escape!(expression)},'"
         end
       end
 
@@ -85,17 +87,19 @@ module EJS
         end
       end
 
-      def escape_function
-        ".replace(/&/g, '&amp;')" +
-        ".replace(/</g, '&lt;')" +
-        ".replace(/>/g, '&gt;')" +
-        ".replace(/\"/g, '&quot;')" +
-        ".replace(/'/g, '&#x27;')" +
-        ".replace(/\\//g,'&#x2F;')"
+      def runtime_escape!(expression)
+        escape_function % expression
       end
   end
 
   self.evaluation_pattern = /<%([\s\S]+?)%>/
   self.interpolation_pattern = /<%=([\s\S]+?)%>/
   self.escape_pattern = /<%-([\s\S]+?)%>/
+  self.escape_function =
+    "%s.replace(/&/g, '&amp;')" +
+    ".replace(/</g, '&lt;')" +
+    ".replace(/>/g, '&gt;')" +
+    ".replace(/\"/g, '&quot;')" +
+    ".replace(/'/g, '&#x27;')" +
+    ".replace(/\\//g,'&#x2F;')"
 end

--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -70,8 +70,7 @@ module EJS
 
       def replace_escape_tags!(source, options)
         source.gsub!(options[:escape_pattern] || escape_pattern) do
-          expression = "(''+#{js_unescape!($1)})"
-          "',#{runtime_escape!(expression)},'"
+          "',#{runtime_escape!(js_unescape!($1))},'"
         end
       end
 
@@ -96,7 +95,7 @@ module EJS
   self.interpolation_pattern = /<%=([\s\S]+?)%>/
   self.escape_pattern = /<%-([\s\S]+?)%>/
   self.escape_function =
-    "%s.replace(/&/g, '&amp;')" +
+    "('' + %s).replace(/&/g, '&amp;')" +
     ".replace(/</g, '&lt;')" +
     ".replace(/>/g, '&gt;')" +
     ".replace(/\"/g, '&quot;')" +

--- a/test/test_ejs.rb
+++ b/test/test_ejs.rb
@@ -39,6 +39,25 @@ class EJSCompilationTest < Test::Unit::TestCase
   end
 end
 
+class EJSCustomEscapeFunctionTest < Test::Unit::TestCase
+  extend TestHelper
+
+  def setup
+    @original_escape_function = EJS.escape_function
+    EJS.escape_function = '_.escape(%s)'
+  end
+
+  def teardown
+    EJS.escape_function = @original_escape_function
+  end
+
+  test 'compile' do
+    result = EJS.compile('<%- name %>')
+    assert_match /_\.escape\(.+\)/, result
+  end
+
+end
+
 class EJSCustomPatternTest < Test::Unit::TestCase
   extend TestHelper
 

--- a/test/test_ejs.rb
+++ b/test/test_ejs.rb
@@ -53,7 +53,7 @@ class EJSCustomEscapeFunctionTest < Test::Unit::TestCase
 
   test 'compile' do
     result = EJS.compile('<%- name %>')
-    assert_match /_\.escape\(.+\)/, result
+    assert_match /_\.escape\(\s*name\s*\)/, result
   end
 
 end


### PR DESCRIPTION
EJS.escape_function is now a formatting string.
Example:

``` ruby
EJS.escape_function = '_.escape(%s)'
```
