### PR TITLE
Fix for turnaries always being truthy when passed to escaping EJS tags.

### DIFF
--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -69,7 +69,7 @@ module EJS
 
       def replace_escape_tags!(source, options)
         source.gsub!(options[:escape_pattern] || escape_pattern) do
-          "',(''+#{js_unescape!($1)})#{escape_function},'"
+          "',(''+(#{js_unescape!($1)}))#{escape_function},'"
         end
       end
 


### PR DESCRIPTION
The implementation was prepending an empty string blindly to the front of the fragment provided to the tags which caused the turnary to always be evaluated truthily.

Example:

``` javascript
<%- this.ad.activity ? this.ad.activity.activity : "" %>
```

...was producing:

``` javascript
(''+this.ad.activity ? this.ad.activity.activity : "")
```

... which is always truthy because of the type coercion.  It now produces:

``` javascript
(''+(this.ad.activity ? this.ad.activity.activity : ""))
```

... which properly honors the intention of the evaluation.
