### PR TITLE
add EJS.variable_name to mirror Underscore template variable option

### DIFF
--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -39,7 +39,7 @@ module EJS
       replace_escape_tags!(source, options)
       replace_interpolation_tags!(source, options)
       replace_evaluation_tags!(source, options)
-      source = assemble_source(source);
+      source = assemble_source(source)
       "function(#{variable_name || 'obj'}){" +
         "var __p=[],print=function(){__p.push.apply(__p,arguments);};" +
         "#{source}" +

--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -20,6 +20,7 @@ module EJS
     attr_accessor :evaluation_pattern
     attr_accessor :interpolation_pattern
     attr_accessor :escape_pattern
+    attr_accessor :variable_name
 
     # Compiles an EJS template to a JavaScript function. The compiled
     # function takes an optional argument, an object specifying local
@@ -38,10 +39,21 @@ module EJS
       replace_escape_tags!(source, options)
       replace_interpolation_tags!(source, options)
       replace_evaluation_tags!(source, options)
-      "function(obj){var __p=[],print=function(){__p.push.apply(__p,arguments);};" +
-        "with(obj||{}){__p.push('#{source}');}return __p.join('');}"
+      source = assemble_source(source);
+      "function(#{variable_name || 'obj'}){" +
+        "var __p=[],print=function(){__p.push.apply(__p,arguments);};" +
+        "#{source}" +
+        "return __p.join('');}"
     end
 
+    # build string to use as source
+    def assemble_source(source)
+      source = "__p.push('#{source}');"
+      if !variable_name
+        source = "with(obj||{}){#{source}}";
+      end
+      source
+    end
     # Evaluates an EJS template with the given local variables and
     # compiler options. You will need the ExecJS
     # (https://github.com/sstephenson/execjs/) library and a

--- a/test/test_ejs.rb
+++ b/test/test_ejs.rb
@@ -198,3 +198,15 @@ class EJSEvaluationTest < Test::Unit::TestCase
     assert_equal "&#x27;Foo Bar&#x27;", EJS.evaluate(template, { :foobar => "'Foo Bar'" }, QUESTION_MARK_SYNTAX)
   end
 end
+
+class EJSVariableNameTest < Test::Unit::TestCase
+  extend TestHelper
+
+  test "compile with custom variable name" do
+    EJS.variable_name = 'data'
+    result = EJS.compile("Hello")
+    assert_match(%r(function\(data\)), result)
+    assert_no_match(%r(with), result)
+    EJS.variable_name = nil
+  end
+end

--- a/test/test_ejs.rb
+++ b/test/test_ejs.rb
@@ -209,4 +209,10 @@ class EJSVariableNameTest < Test::Unit::TestCase
     assert_no_match(%r(with), result)
     EJS.variable_name = nil
   end
+  test 'compile without custom variable name' do
+    EJS.variable_name = nil
+    result = EJS.compile("Hello")
+    assert_match(%r(function\(obj\)), result)
+    assert_match(%r(with\(obj\|\|{}\)), result)
+  end
 end


### PR DESCRIPTION
Underscore's _.template method supports a `variable` option to allow for templates to use the defined variable name instead of local scope.  
http://underscorejs.org/#template

This branch ports existing Underscore behavior to EJS by adding the `EJS.variable_name` option.

One nice side effect of this change is that rendering no longer uses the Javascript `with` statement which is slow and should generally be avoided whenever possible.

Resources:  
- http://jsperf.com/with-statement/4
- http://www.yuiblog.com/blog/2006/04/11/with-statement-considered-harmful/
