### PR TITLE
Coerce null/undefined to empty string when escaping

### DIFF
--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -69,7 +69,7 @@ module EJS
 
       def replace_escape_tags!(source, options)
         source.gsub!(options[:escape_pattern] || escape_pattern) do
-          "',(''+#{js_unescape!($1)})#{escape_function},'"
+          "',#{coerce_to_string_function}(#{js_unescape!($1)})#{escape_function},'"
         end
       end
 
@@ -83,6 +83,12 @@ module EJS
         source.gsub!(options[:interpolation_pattern] || interpolation_pattern) do
           "', #{js_unescape!($1)},'"
         end
+      end
+
+      def coerce_to_string_function
+        "function(s) {" +
+          "return (s === null || typeof(s) === 'undefined') ? '' : ('' + s);" +
+        "}"
       end
 
       def escape_function

--- a/test/test_ejs.rb
+++ b/test/test_ejs.rb
@@ -168,6 +168,12 @@ class EJSEvaluationTest < Test::Unit::TestCase
 
     template = "<%- foobar %>"
     assert_equal "&#x27;Foo Bar&#x27;", EJS.evaluate(template, { :foobar => "'Foo Bar'" })
+
+    template = "<%- null %>"
+    assert_equal "", EJS.evaluate(template, {})
+
+    template = "<%- undefined %>"
+    assert_equal "", EJS.evaluate(template, {})
   end
 
   test "braced escaping" do
@@ -182,6 +188,12 @@ class EJSEvaluationTest < Test::Unit::TestCase
 
     template = "{{- foobar }}"
     assert_equal "&#x27;Foo Bar&#x27;", EJS.evaluate(template, { :foobar => "'Foo Bar'" }, BRACE_SYNTAX)
+
+    template = "{{- null }}"
+    assert_equal "", EJS.evaluate(template, {}, BRACE_SYNTAX)
+
+    template = "{{- undefined }}"
+    assert_equal "", EJS.evaluate(template, {}, BRACE_SYNTAX)
   end
 
   test "question-mark escaping" do
@@ -196,5 +208,11 @@ class EJSEvaluationTest < Test::Unit::TestCase
 
     template = "<?- foobar ?>"
     assert_equal "&#x27;Foo Bar&#x27;", EJS.evaluate(template, { :foobar => "'Foo Bar'" }, QUESTION_MARK_SYNTAX)
+
+    template = "<?- null ?>"
+    assert_equal "", EJS.evaluate(template, {}, QUESTION_MARK_SYNTAX)
+
+    template = "<?- undefined ?>"
+    assert_equal "", EJS.evaluate(template, {}, QUESTION_MARK_SYNTAX)
   end
 end


### PR DESCRIPTION
When you use escape tags with a null value it will be turned into the string "null", which can be incredibly inconvenient.

For example

```
value: "<%- null %>"
```

becomes

```
value: "null"
```

This patch changes the result to:

```
value: ""
```

This is consistent with the behavior of e.g. erb
