### PR TITLE
Add license to gemspec

### DIFF
--- a/ejs.gemspec
+++ b/ejs.gemspec
@@ -11,4 +11,5 @@ Gem::Specification.new do |s|
   s.authors = ["Sam Stephenson"]
   s.email = ["sstephenson@gmail.com"]
   s.homepage = "https://github.com/sstephenson/ruby-ejs/"
+  s.license = 'MIT'
 end


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.
