### PR TITLE
remove newlines and whitespaces between html tags

### DIFF
--- a/lib/ejs.rb
+++ b/lib/ejs.rb
@@ -34,6 +34,7 @@ module EJS
     def compile(source, options = {})
       source = source.dup
 
+      remove_html_trailing_whitespaces!(source)
       js_escape!(source)
       replace_escape_tags!(source, options)
       replace_interpolation_tags!(source, options)
@@ -57,6 +58,11 @@ module EJS
     end
 
     protected
+      def remove_html_trailing_whitespaces!(source)
+        source.gsub!(/>[[:space:]]*$[[:space:]]*</im, '><')
+        source
+      end
+
       def js_escape!(source)
         source.gsub!(JS_ESCAPE_PATTERN) { |match| '\\' + JS_ESCAPES[match] }
         source

--- a/test/test_ejs.rb
+++ b/test/test_ejs.rb
@@ -122,6 +122,11 @@ class EJSEvaluationTest < Test::Unit::TestCase
     assert_equal "This\n\t\tis: that.\n\tok.\nend.", EJS.evaluate(template, :x => "that")
   end
 
+  test "newlines and whitespaces between html tags" do
+    template = "<div>\t \t \n\t<div class=\"test\">\t\t\n\t  < span ><strong> <%= x %> </strong ></span>    \t\t\n\t  <% if(y) { %>\n\t  <span>that</span> text spaces and \n multilines \n\t\n should be kept \t\n\t  intact\n\t  <% } %>     \t\t\n  </div>\t\t\n\</div>\n"
+    assert_equal "<div><div class=\"test\">< span ><strong> this </strong ></span><span>that</span> text spaces and \n multilines \n\t\n should be kept \t\n\t  intact\n\t  </div></div>\n", EJS.evaluate(template, :x => "this", :y => true)
+  end
+
 
   test "braced iteration" do
     template = "<ul>{{ for (var i = 0; i < people.length; i++) { }}<li>{{= people[i] }}</li>{{ } }}</ul>"


### PR DESCRIPTION
I've added a small regex to remove indentation whitespaces between html tags.
I'm open for any suggestions
