### PR TITLE
Add Travis CI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.bundle
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: ruby
+
+sudo: false
+
+before_install:
+  - gem install bundler
+
+rvm:
+  - 2.0.0
+  - 2.1.10
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/ejs.gemspec
+++ b/ejs.gemspec
@@ -7,6 +7,8 @@ Gem::Specification.new do |s|
   s.files = Dir["README.md", "LICENSE", "lib/**/*.rb"]
 
   s.add_development_dependency "execjs", "~> 0.4"
+  s.add_development_dependency "rake", "~> 12.0.0"
+  s.add_development_dependency "test-unit", "~> 3.2.3"
 
   s.authors = ["Sam Stephenson"]
   s.email = ["sstephenson@gmail.com"]


### PR DESCRIPTION
Hello @sstephenson ,
I send a pull-request to use Travis CI.
`ejs` is used a development dependency of `sprockets` that is used as a part of Rails.
So, it is important for me to maintain this package.

I added ruby-head as allow_failures.
I think this is useful.
Because we can prepare before next version Ruby 2.5 release.
Though it might not be useful until the actual preview release.
We can support the next version as faster.

We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.
I think that is the reason why `rails` and `rspec` can support new version Ruby as faster.

https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

fast_finish is to get the Travis result as faster without waiting the result of the "allow_failures" items.
See https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/

Is it possible to activate this repo's Travis at first?
https://travis-ci.org/sstephenson/ruby-ejs

Thanks.
